### PR TITLE
Make bind credentials optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ Another common, although in some ways more limited, approach is defining DNs as 
 Basic configuration in `Foundation.hs`:
 ```haskell
 ldapConf :: LdapAuthConf
-ldapConf = 
+ldapConf =
     setHost (Secure "127.0.0.1") $ setPort 636
-  $ mkLdapConf "cn=Manager,dc=example,dc=com" "v3ryS33kret"
+  $ mkLdapConf (Just ("cn=Manager,dc=example,dc=com", "v3ryS33kret"))
       "ou=people,dc=example,dc=com"
 ```
 
@@ -35,12 +35,11 @@ setHost (Plain "127.0.0.1")
 For additional group authentication use `setGroupQuery`:
 ```haskell
  ldapConf :: LdapAuthConf
- ldapConf = 
+ ldapConf =
      setGroupQuery (Just $ mkGroupQuery
        "ou=group,dc=example,dc=com" "cn" "it" "memberUid")
    $ setHost (Secure "127.0.0.1") $ setPort 636
-   $ mkLdapConf "cn=yourapp,ou=services,dc=example,dc=com"
-       "v3ryS33kret"
+   $ mkLdapConf (Just ("cn=yourapp,ou=services,dc=example,dc=com", "v3ryS33kret"))
        "ou=people,dc=example,dc=com"
 ```
 

--- a/src/Yesod/Auth/LdapNative.hs
+++ b/src/Yesod/Auth/LdapNative.hs
@@ -17,17 +17,18 @@
 ----------------------------------------------------------------------------
 
 module Yesod.Auth.LdapNative
-  ( 
+  (
   -- * Usage
   -- $use
 
   -- * Plugin Configuration
     authLdap
   , authLdapWithForm
-  
+
   -- * LDAP Configuration
   , LdapAuthConf
   , LdapAuthQuery (..)
+  , LdapCreds (..)
   , mkLdapConf
   , mkGroupQuery
   , setHost
@@ -61,22 +62,27 @@ loginRoute :: AuthRoute
 loginRoute = PluginR pluginName ["login"]
 
 -- | LDAP configuration.
--- 
+--
 -- Details hidden on purpose.
 -- Use 'mkLdapConf' to create default config and functions below to adjust to taste.
 data LdapAuthConf = LdapAuthConf
   -- connection
   { host   :: L.Host
   , port   :: L.PortNumber
-  , bindDn :: L.Dn
-  , bindPw :: L.Password
-  
+  , bindCreds :: Maybe LdapCreds
+
   -- queries
   , userQuery  :: LdapAuthQuery
   , groupQuery :: Maybe LdapAuthQuery
 
   -- other
   , debug  :: Int
+  }
+
+-- | LDAP dn and password
+data LdapCreds = LdapCreds
+  { lcDn :: L.Dn
+  , lcPw :: L.Password
   }
 
 -- | Query parameters.
@@ -86,21 +92,19 @@ data LdapAuthQuery = LdapAuthQuery L.Dn (L.Mod L.Search) (Text -> L.Filter) [L.A
 
 -- | Default LDAP configuration.
 mkLdapConf
-  :: Text     -- ^ bindDn
-  -> Text     -- ^ bindPw
+  :: Maybe (Text, Text)     -- ^ bindDn and bindPw
   -> Text     -- ^ user query baseDn
   -> LdapAuthConf
-mkLdapConf bindDn bindPw baseDn = LdapAuthConf
+mkLdapConf mbindc baseDn = LdapAuthConf
   { host   = L.Secure "localhost"
   , port   = 636
-  , bindDn = L.Dn bindDn
-  , bindPw = L.Password (T.encodeUtf8 bindPw)
-
+  , bindCreds = (\(dn,p) -> LdapCreds (L.Dn dn) (L.Password $ T.encodeUtf8 p)) <$> mbindc
   , userQuery  = mkUserQuery baseDn
   , groupQuery = Nothing
 
   , debug = 0
   }
+-- (Just (bindDn,bindPw))
 
 -- | Default LDAP user query.
 mkUserQuery
@@ -147,7 +151,7 @@ setGroupQuery q conf = conf { groupQuery = q }
 -- Do not use in production.
 setDebug :: Int -> LdapAuthConf -> LdapAuthConf
 setDebug level conf = conf { debug = level }
-  
+
 
 authLdap :: YesodAuth m => LdapAuthConf -> AuthPlugin m
 authLdap conf = authLdapWithForm conf defaultForm
@@ -185,7 +189,7 @@ dispatchLdap conf = do
     Right (L.SearchEntry _ attrs) -> do
       let extra = map f attrs
       lift $ setCredsRedirect $ Creds pluginName username extra
-  
+
   where
     f (L.Attr k, x : _) = (k, T.decodeUtf8 x)
     f (L.Attr k, _)     = (k, "")
@@ -216,10 +220,12 @@ data LdapAuthError =
 ldapLogin :: LdapAuthConf -> Text -> Text -> IO (Either LdapAuthError L.SearchEntry)
 ldapLogin conf user pw = do
   res <- L.with (host conf) (port conf) $ \l ->
-    
+
     runEitherT $ do
       -- service bind
-      esb <- lift $ L.bindEither l (bindDn conf) (bindPw conf)
+      esb <- case bindCreds conf of
+              Just c -> lift $ L.bindEither l (lcDn c) (lcPw c)
+              Nothing -> return $ Right ()
       case esb of
         Right _ -> return ()
         Left _ -> left ServiceBindError
@@ -239,7 +245,7 @@ ldapLogin conf user pw = do
               Nothing -> return $ Right []
       case eg of
         -- either becase groupQuery was not provided or returned nothing
-        Right [] -> case mg of 
+        Right [] -> case mg of
                       Just _  -> left GroupMembershipError
                       Nothing -> return ()
         Right _  -> return ()
@@ -252,7 +258,6 @@ ldapLogin conf user pw = do
         Left _  -> left UserBindError
 
       return se
-
   case res of
     Left err -> return $ Left $ LdapError err
     Right x -> return x
@@ -286,7 +291,7 @@ defaultForm loginR = [whamlet|
 -- Basic configuration in Foundation.hs:
 --
 -- > ldapConf :: LdapAuthConf
--- > ldapConf = 
+-- > ldapConf =
 -- >     setHost (Secure "127.0.0.1") $ setPort 636
 -- >   $ mkLdapConf "cn=Manager,dc=example,dc=com" "v3ryS33kret" "ou=people,dc=example,dc=com"
 --
@@ -299,7 +304,7 @@ defaultForm loginR = [whamlet|
 -- For additional group authentication use 'setGroupQuery':
 --
 -- > ldapConf :: LdapAuthConf
--- > ldapConf = 
+-- > ldapConf =
 -- >     setGroupQuery (Just $ mkGroupQuery "ou=group,dc=example,dc=com" "cn" "it" "memberUid")
 -- >   $ setHost (Secure "127.0.0.1") $ setPort 636
 -- >   $ mkLdapConf "cn=yourapp,ou=services,dc=example,dc=com" "v3ryS33kret" "ou=people,dc=example,dc=com"
@@ -315,5 +320,5 @@ defaultForm loginR = [whamlet|
 -- When testing or during initial configuration consider using 'setDebug' - set to 1 to enable. This will
 -- give you exact error condition instead of "That is all we know". Never use it in production though as it
 -- may reveal sensitive information.
--- 
+--
 -- Refer to 'ldap-client' documentation for details.

--- a/src/Yesod/Auth/LdapNative.hs
+++ b/src/Yesod/Auth/LdapNative.hs
@@ -293,7 +293,7 @@ defaultForm loginR = [whamlet|
 -- > ldapConf :: LdapAuthConf
 -- > ldapConf =
 -- >     setHost (Secure "127.0.0.1") $ setPort 636
--- >   $ mkLdapConf "cn=Manager,dc=example,dc=com" "v3ryS33kret" "ou=people,dc=example,dc=com"
+-- >   $ mkLdapConf (Just ("cn=Manager,dc=example,dc=com", "v3ryS33kret")) "ou=people,dc=example,dc=com"
 --
 -- And add __authLdap ldapConf__ to your __authPlugins__.
 --
@@ -307,7 +307,7 @@ defaultForm loginR = [whamlet|
 -- > ldapConf =
 -- >     setGroupQuery (Just $ mkGroupQuery "ou=group,dc=example,dc=com" "cn" "it" "memberUid")
 -- >   $ setHost (Secure "127.0.0.1") $ setPort 636
--- >   $ mkLdapConf "cn=yourapp,ou=services,dc=example,dc=com" "v3ryS33kret" "ou=people,dc=example,dc=com"
+-- >   $ mkLdapConf (Just ("cn=yourapp,ou=services,dc=example,dc=com", "v3ryS33kret")) "ou=people,dc=example,dc=com"
 --
 -- In the example above user jdoe will only be successfully authenticated when:
 --

--- a/yesod-auth-ldap-native.cabal
+++ b/yesod-auth-ldap-native.cabal
@@ -1,5 +1,5 @@
 name:                yesod-auth-ldap-native
-version:             0.1.0.2
+version:             0.2.0.0
 synopsis:            Yesod LDAP authentication plugin
 description:         This package provides an LDAP authentication plugin for Yesod.
 homepage:            http://github.com/mulderr/yesod-auth-ldap-native


### PR DESCRIPTION
In my use case the site that asks for credentials and LDAP server are under the same domain and local network, therefore I don't need bind credentials.

I do a major version change because `mkLdapConf`has been changed a bit.
